### PR TITLE
Remove `import TensorFlow` statement.

### DIFF
--- a/generate_wrappers.py
+++ b/generate_wrappers.py
@@ -55,7 +55,6 @@ _HEADER = """// Copyright 2018 Google LLC
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import TensorFlow
 """
 
 _OUTPUT_FILE = 'RawOpsGenerated.swift'


### PR DESCRIPTION
This fixes the warning:
`file 'RawOpsGenerated.swift' is part of module 'TensorFlow'; ignoring import`