### PR TITLE
 Fix the script to take care of '(' and ')' in allowed string attributes.

### DIFF
--- a/RawOpsGenerated.swift
+++ b/RawOpsGenerated.swift
@@ -292,9 +292,9 @@ public enum Mode4 {
 
 // @_frozen // SR-9739
 public enum OutputStream {
-  case log(error)
-  case log(info)
-  case log(warning)
+  case logError
+  case logInfo
+  case logWarning
   case stderr
   case stdout
 
@@ -303,9 +303,9 @@ public enum OutputStream {
     @inline(__always)
     get {
       switch self {
-      case .log(error): return "log(error)"
-      case .log(info): return "log(info)"
-      case .log(warning): return "log(warning)"
+      case .logError: return "log(error)"
+      case .logInfo: return "log(info)"
+      case .logWarning: return "log(warning)"
       case .stderr: return "stderr"
       case .stdout: return "stdout"
       }

--- a/generate_wrappers.py
+++ b/generate_wrappers.py
@@ -145,12 +145,12 @@ def swift_compatible(s, capitalize=False):
   if capitalize:
     s = s.capitalize()
   without_underscores = []
-  prev_char_was_underscore = False
+  capitalize_next_char = False
   for c in s:
-    if c == '_':
-      prev_char_was_underscore = True
-    elif prev_char_was_underscore:
-      prev_char_was_underscore = False
+    if c == '_' or c == '(' or c == ')':
+      capitalize_next_char = True
+    elif capitalize_next_char:
+      capitalize_next_char = False
       without_underscores.append(c.upper())
     else:
       without_underscores.append(c)


### PR DESCRIPTION
This also updates the generated op to fix the compiler errors. 