### PR TITLE
Remove makeOp so that it can be moved to CompilerRuntime.swift

### DIFF
--- a/TFTensorOperation.swift
+++ b/TFTensorOperation.swift
@@ -1,11 +1,3 @@
-extension _ExecutionContext {
-  // The execution mode is effectively encoded in the TensorOperation.
-  // We can use this to switch between different execution modes.
-  // TODO: Can we interop between modes?
-  public static func makeOp(_ name: String, _ nOutputs: Int) -> TFTensorOperation {
-    return TFE_Op(name, nOutputs)
-  }
-}
 
 // A protocol for a tensor operation.
 public protocol TensorOperation {


### PR DESCRIPTION
This PR breaks the build of stdlib, but is needed to move the implementation to CompilerRuntime.swift.